### PR TITLE
refactor(frontend): reverse upcoming events order

### DIFF
--- a/frontend/lib/api.tsx
+++ b/frontend/lib/api.tsx
@@ -117,7 +117,7 @@ export async function loadUpcomingEvents() {
   const res = await client
     .getEntries({
       content_type: 'upcomingEvents',
-      order: '-fields.index',
+      order: 'fields.index',
     })
     .catch((error) => {
       console.error(error);
@@ -222,7 +222,7 @@ export async function loadNextUpcomingEvent() {
   const res = await client
     .getEntries({
       content_type: 'upcomingEvents',
-      order: '-fields.index',
+      order: 'fields.index',
       limit: 1,
     })
     .catch((error) => {


### PR DESCRIPTION
- Reverse the order in which upcoming events are fetched from Contentful so that the oldest event (i.e. the event that will be held the soonest) appears on the Home page and on the leftmost side of the Events page.