### PR TITLE
bugfix(frontend): prevent image stretching on blog posts

### DIFF
--- a/frontend/styles/BlogPost.module.css
+++ b/frontend/styles/BlogPost.module.css
@@ -81,6 +81,7 @@
 .image {
   margin: 0 auto;
   max-width: 85%;
+  height: auto;
   justify-content: center;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
- add `height: auto;` property to the `.image` class to stop blog images from stretching