### PR TITLE
feat: add 'Blogs' category to marketing archives

### DIFF
--- a/frontend/data/marketing.ts
+++ b/frontend/data/marketing.ts
@@ -15,6 +15,7 @@ const categories = {
   'Monday Motivation': 'Monday',
   'WIT Crush Wednesday': 'WCW',
   'Special Occasions': 'Special',
+  Blogs: 'Blogs',
 };
 
 const marks = [


### PR DESCRIPTION
- Add 'Blogs' category to the Marketing Archives page and Content Model